### PR TITLE
Added test case for nullable enum that defaults to null and defaults …

### DIFF
--- a/src/test/kotlin/com/github/avrokotlin/avro4k/schema/EnumSchemaTest.kt
+++ b/src/test/kotlin/com/github/avrokotlin/avro4k/schema/EnumSchemaTest.kt
@@ -68,6 +68,18 @@ class EnumSchemaTest : WordSpec({
 
          schema.toString(true) shouldBe expected.toString(true)
       }
+      "generate schema with default and nullable union types" {
+         @Serializable
+         data class EnumWithDefaultTest(
+            @AvroDefault(Avro.NULL) val type: DefaultIngredientType?
+         )
+         val expected =
+            org.apache.avro.Schema.Parser().parse(javaClass.getResourceAsStream("/enum_with_default_value_and_null.json"))
+
+         val schema = Avro.default.schema(EnumWithDefaultTest.serializer())
+
+         schema.toString(true) shouldBe expected.toString(true)
+      }
       "fail with unknown values" {
          @Serializable
          data class EnumWithDefaultTest(
@@ -92,3 +104,6 @@ enum class Suit{
 
 @Serializable
 enum class IngredientType { VEGGIE, MEAT, }
+
+@Serializable
+data class DefaultIngredientType(@AvroDefault("MEAT") val type: IngredientType)

--- a/src/test/resources/enum_with_default_value_and_null.json
+++ b/src/test/resources/enum_with_default_value_and_null.json
@@ -1,0 +1,23 @@
+{
+   "type" : "record",
+   "name" : "EnumWithDefaultTest",
+   "namespace" : "com.github.avrokotlin.avro4k.schema.EnumSchemaTest",
+   "fields" : [ {
+      "name" : "type",
+      "type" : [ "null", {
+         "type" : "record",
+         "name" : "DefaultIngredientType",
+         "namespace" : "com.github.avrokotlin.avro4k.schema",
+         "fields" : [ {
+            "name" : "type",
+            "type" : {
+               "type" : "enum",
+               "name" : "IngredientType",
+               "symbols" : [ "VEGGIE", "MEAT" ],
+               "default" : "MEAT"
+            }
+         } ]
+      } ],
+      "default" : null
+   } ]
+}


### PR DESCRIPTION
…to an enum value is not null.

Hi Kossi,

Thank you for looking at this issue so quick!
Your solution looks good.

I added one test case. I wanted to see if I could make it work for a nullable enum that defaults to null and defaults to a value in the enum if it is not null.
I had to create a data class with just the enum in it and give it the default value, then make that enum class the nullable field for it to work. I could not think of another way to do it since I can't give an enum two default values. Even if I could, I don't know how it would choose which to use.
I just wanted to see if it were possible because I'm sure cases will come up where the value can be null and if it is not, people will want the value to have a default for backward compatibility.